### PR TITLE
Fix test env initialization

### DIFF
--- a/tests/container-scripts/run-testnet.sh
+++ b/tests/container-scripts/run-testnet.sh
@@ -21,8 +21,8 @@ do
         RPC_ADDRESS="--rpc.laddr tcp://0.0.0.0:26657"
         GRPC_ADDRESS="--grpc.address 0.0.0.0:9090"
         GRPC_WEB_ADDRESS="--grpc-web.address 0.0.0.0:9092"
-        ETH_RPC_ADDRESS="--json-rpc.address 127.0.0.1:8545"
-        ETH_WS_RPC_ADDRESS="--json-rpc.ws-address 127.0.0.1:8546"
+        ETH_RPC_ADDRESS="--json-rpc.address 0.0.0.0:8545"
+        ETH_RPC_WS_ADDRESS="--json-rpc.ws-address 0.0.0.0:8546"
         sed -i 's/enable-unsafe-cors = false/enable-unsafe-cors = true/g' /validator$i/config/app.toml
         sed -i 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/g' /validator$i/config/app.toml
         sed -i 's/enable = false/enable = true/g' /validator$i/config/app.toml #enables more than we want, but will work for now
@@ -35,13 +35,13 @@ do
         GRPC_ADDRESS="--grpc.address 7.7.7.$i:9091"
         GRPC_WEB_ADDRESS="--grpc-web.address 7.7.7.$i:9093"
         ETH_RPC_ADDRESS="--json-rpc.address 7.7.7.$i:8545"
-        ETH_WS_RPC_ADDRESS="--json-rpc.ws-address 7.7.7.$i:8546"
+        ETH_RPC_WS_ADDRESS="--json-rpc.address 7.7.7.$i:8546"
     fi
     LISTEN_ADDRESS="--address tcp://7.7.7.$i:26655"
     P2P_ADDRESS="--p2p.laddr tcp://7.7.7.$i:26656"
     LOG_LEVEL="--log_level info"
     INVARIANTS_CHECK="--inv-check-period 1"
-    ARGS="$GAIA_HOME $LISTEN_ADDRESS $RPC_ADDRESS $GRPC_ADDRESS $GRPC_WEB_ADDRESS $ETH_RPC_ADDRESS $ETH_WS_RPC_ADDRESS $INVARIANTS_CHECK $LOG_LEVEL $P2P_ADDRESS"
+    ARGS="$GAIA_HOME $LISTEN_ADDRESS $RPC_ADDRESS $GRPC_ADDRESS $GRPC_WEB_ADDRESS $ETH_RPC_ADDRESS $ETH_RPC_WS_ADDRESS $INVARIANTS_CHECK $LOG_LEVEL $P2P_ADDRESS"
     $BIN $ARGS start &> /validator$i/logs &
 done
 

--- a/tests/start-chains.sh
+++ b/tests/start-chains.sh
@@ -15,4 +15,4 @@ NODES=3
 pushd $DIR/../
 
 # Run new test container instance
-docker run --name althea_test_instance --mount type=bind,source="$(pwd)"/,target=/althea --cap-add=NET_ADMIN -p 2345:2345 -p 9090:9090 -p 26657:26657 -p 1317:1317 -p 8545:8545 -it althea-base /bin/bash /althea/tests/container-scripts/reload-code.sh $NODES
+docker run --name althea_test_instance --mount type=bind,source="$(pwd)"/,target=/althea --cap-add=NET_ADMIN -p 2345:2345 -p 9090:9090 -p 9091:9092 -p 26657:26657 -p 1317:1317 -p 8545:8545 -it althea-base /bin/bash /althea/tests/container-scripts/reload-code.sh $NODES


### PR DESCRIPTION
Previously the test environment had and incorrect configuration of the ETH RPC, and a bandaid was put in place. This commit fixes that initialization by adding the websocket configuration and exposes the websocket port in addition to the regular JSONRPC port.