### PR TITLE
Charge NFT contract deploy gas on MsgLiquify

### DIFF
--- a/integration_tests/test_runner/src/tests/liquid_accounts.rs
+++ b/integration_tests/test_runner/src/tests/liquid_accounts.rs
@@ -73,7 +73,10 @@ pub async fn liquid_accounts_test(
     )
     .await
     .expect("Unable to liquify account");
-    info!("Got liquify account response:\n{}", liquify_res.raw_log);
+    info!(
+        "Got liquify account response:\n{}\nTx Hash: {}\nGas used: {}",
+        liquify_res.raw_log, liquify_res.txhash, liquify_res.gas_used
+    );
 
     let (liquid_account, _eth_owner) =
         assert_correct_account(web3, &mut microtx_qc, to_liquify.ethermint_address).await;
@@ -227,7 +230,7 @@ pub async fn liquify_account(
             to_liquify,
             Fee {
                 amount: vec![fee],
-                gas_limit: 1_000_000,
+                gas_limit: 2_500_000,
                 payer: None,
                 granter: None,
             },

--- a/x/microtx/keeper/msg_server.go
+++ b/x/microtx/keeper/msg_server.go
@@ -166,6 +166,10 @@ func (m *msgServer) Liquify(c context.Context, msg *types.MsgLiquify) (*types.Ms
 		return nil, sdkerrors.Wrap(sdkerrors.ErrorInvalidSigner, "liquid infrastructure accounts must use ethermint keys, perhaps this is the first message the sender has sent?")
 	}
 
+	if m.Keeper.IsLiquidAccount(ctx, sender) {
+		return nil, types.ErrAccountAlreadyLiquid
+	}
+
 	// Call the actual liquify implementation
 	nft, err := m.Keeper.DoLiquify(ctx, sender)
 	if err != nil {

--- a/x/microtx/types/errors.go
+++ b/x/microtx/types/errors.go
@@ -5,10 +5,11 @@ import (
 )
 
 var (
-	ErrContractDeployment = sdkerrors.Register(ModuleName, 1, "contract deploy failed")
-	ErrContractCall       = sdkerrors.Register(ModuleName, 2, "contract call failed")
-	ErrNoLiquidAccount    = sdkerrors.Register(ModuleName, 3, "account is not a liquid infrastructure account")
-	ErrInvalidThresholds  = sdkerrors.Register(ModuleName, 4, "invalid liquid infrastructure account thresholds")
-	ErrInvalidMicrotx     = sdkerrors.Register(ModuleName, 5, "invalid microtx")
-	ErrInvalidContract    = sdkerrors.Register(ModuleName, 6, "invalid contract")
+	ErrContractDeployment   = sdkerrors.Register(ModuleName, 1, "contract deploy failed")
+	ErrContractCall         = sdkerrors.Register(ModuleName, 2, "contract call failed")
+	ErrNoLiquidAccount      = sdkerrors.Register(ModuleName, 3, "account is not a liquid infrastructure account")
+	ErrInvalidThresholds    = sdkerrors.Register(ModuleName, 4, "invalid liquid infrastructure account thresholds")
+	ErrInvalidMicrotx       = sdkerrors.Register(ModuleName, 5, "invalid microtx")
+	ErrInvalidContract      = sdkerrors.Register(ModuleName, 6, "invalid contract")
+	ErrAccountAlreadyLiquid = sdkerrors.Register(ModuleName, 7, "account is already a liquid infrastructure account")
 )


### PR DESCRIPTION
~Merge after #49 is merged and this branch is rebased~

Promising issue found in development: the old gas limit of 1,000,000 was not sufficient after the `Charge liquified account gas on MsgLiquify` change, the new limit needed to be 2,500,000 gas, because the test was using 2347396 locally.