### PR TITLE
WIP: Set proper account types + pubkeys

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -1,0 +1,55 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+
+	ethante "github.com/evmos/ethermint/app/ante"
+)
+
+// NewAnteHandler returns an ante handler responsible for attempting to route an
+// Ethereum or SDK transaction to an internal ante handler for performing
+// transaction-level processing (e.g. fee payment, signature verification) before
+// being passed onto it's respective handler.
+func NewAnteHandler(options HandlerOptions) sdk.AnteHandler {
+	return func(
+		ctx sdk.Context, tx sdk.Tx, sim bool,
+	) (newCtx sdk.Context, err error) {
+		var anteHandler sdk.AnteHandler
+
+		defer ethante.Recover(ctx.Logger(), &err)
+
+		txWithExtensions, ok := tx.(authante.HasExtensionOptionsTx)
+		if ok {
+			opts := txWithExtensions.GetExtensionOptions()
+			if len(opts) > 0 {
+				switch typeURL := opts[0].GetTypeUrl(); typeURL {
+				case "/ethermint.evm.v1.ExtensionOptionsEthereumTx":
+					// handle as *evmtypes.MsgEthereumTx
+					anteHandler = newEthAnteHandler(options)
+				case "/ethermint.types.v1.ExtensionOptionsWeb3Tx":
+					// handle as normal Cosmos SDK tx, except signature is checked for EIP712 representation
+					anteHandler = newCosmosAnteHandlerEip712(options)
+				default:
+					return ctx, sdkerrors.Wrapf(
+						sdkerrors.ErrUnknownExtensionOptions,
+						"rejecting tx with unsupported extension option: %s", typeURL,
+					)
+				}
+
+				return anteHandler(ctx, tx, sim)
+			}
+		}
+
+		// handle as totally normal Cosmos SDK tx
+		switch tx.(type) {
+		case sdk.Tx:
+			anteHandler = newCosmosAnteHandler(options)
+		default:
+			return ctx, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "invalid transaction type: %T", tx)
+		}
+
+		return anteHandler(ctx, tx, sim)
+	}
+}

--- a/app/ante/handler_options.go
+++ b/app/ante/handler_options.go
@@ -1,0 +1,128 @@
+package ante
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	ibcante "github.com/cosmos/ibc-go/v4/modules/core/ante"
+	ibckeeper "github.com/cosmos/ibc-go/v4/modules/core/keeper"
+
+	ethante "github.com/evmos/ethermint/app/ante"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+
+	cantoante "github.com/Canto-Network/Canto/v5/app/ante"
+	vestingtypes "github.com/Canto-Network/Canto/v5/x/vesting/types"
+)
+
+// HandlerOptions defines the list of module keepers required to run the canto
+// AnteHandler decorators.
+type HandlerOptions struct {
+	AccountKeeper   evmtypes.AccountKeeper
+	BankKeeper      evmtypes.BankKeeper
+	IBCKeeper       *ibckeeper.Keeper
+	FeeMarketKeeper evmtypes.FeeMarketKeeper
+	StakingKeeper   vestingtypes.StakingKeeper
+	EvmKeeper       ethante.EVMKeeper
+	FeegrantKeeper  ante.FeegrantKeeper
+	SignModeHandler authsigning.SignModeHandler
+	SigGasConsumer  func(meter sdk.GasMeter, sig signing.SignatureV2, params authtypes.Params) error
+	Cdc             codec.BinaryCodec
+	MaxTxGasWanted  uint64
+}
+
+// Validate checks if the keepers are defined
+func (options HandlerOptions) Validate() error {
+	if options.AccountKeeper == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for AnteHandler")
+	}
+	if options.BankKeeper == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for AnteHandler")
+	}
+	if options.StakingKeeper == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrLogic, "staking keeper is required for AnteHandler")
+	}
+	if options.SignModeHandler == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
+	}
+	if options.FeeMarketKeeper == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrLogic, "fee market keeper is required for AnteHandler")
+	}
+	if options.EvmKeeper == nil {
+		return sdkerrors.Wrap(sdkerrors.ErrLogic, "evm keeper is required for AnteHandler")
+	}
+	return nil
+}
+
+// newCosmosAnteHandler creates the default ante handler for Ethereum transactions
+func newEthAnteHandler(options HandlerOptions) sdk.AnteHandler {
+	return sdk.ChainAnteDecorators(
+		ethante.NewEthSetUpContextDecorator(options.EvmKeeper),                         // outermost AnteDecorator. SetUpContext must be called first
+		ethante.NewEthMempoolFeeDecorator(options.EvmKeeper),                           // Check eth effective gas price against the node's minimal-gas-prices config
+		ethante.NewEthMinGasPriceDecorator(options.FeeMarketKeeper, options.EvmKeeper), // Check eth effective gas price against the global MinGasPrice
+		ethante.NewEthValidateBasicDecorator(options.EvmKeeper),
+		ethante.NewEthSigVerificationDecorator(options.EvmKeeper),
+		ethante.NewEthAccountVerificationDecorator(options.AccountKeeper, options.EvmKeeper),
+		ethante.NewCanTransferDecorator(options.EvmKeeper),
+		cantoante.NewEthVestingTransactionDecorator(options.AccountKeeper),
+		ethante.NewEthGasConsumeDecorator(options.EvmKeeper, options.MaxTxGasWanted),
+		ethante.NewEthIncrementSenderSequenceDecorator(options.AccountKeeper),
+		ethante.NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
+		ethante.NewEthEmitEventDecorator(options.EvmKeeper), // emit eth tx hash and index at the very last ante handler.
+	)
+}
+
+// newCosmosAnteHandler creates the default ante handler for Cosmos transactions
+func newCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
+	return sdk.ChainAnteDecorators(
+		ethante.RejectMessagesDecorator{}, // reject MsgEthereumTxs
+		ante.NewSetUpContextDecorator(),
+		ante.NewRejectExtensionOptionsDecorator(),
+		ante.NewValidateBasicDecorator(),
+		ante.NewMempoolFeeDecorator(),
+		ethante.NewMinGasPriceDecorator(options.FeeMarketKeeper, options.EvmKeeper),
+		ante.NewTxTimeoutHeightDecorator(),
+		ante.NewValidateMemoDecorator(options.AccountKeeper),
+		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
+		cantoante.NewVestingDelegationDecorator(options.AccountKeeper, options.StakingKeeper, options.Cdc),
+		cantoante.NewValidatorCommissionDecorator(options.Cdc),
+		// SetPubKeyAccountTypeDecorator must be called before all signature verification decorators
+		NewSetPubKeyAccountTypeDecorator(options.AccountKeeper),
+		ante.NewValidateSigCountDecorator(options.AccountKeeper),
+		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
+		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
+		ibcante.NewAnteDecorator(options.IBCKeeper),
+		ethante.NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
+	)
+}
+
+// newCosmosAnteHandlerEip712 creates the ante handler for transactions signed with EIP712
+func newCosmosAnteHandlerEip712(options HandlerOptions) sdk.AnteHandler {
+	return sdk.ChainAnteDecorators(
+		ethante.RejectMessagesDecorator{}, // reject MsgEthereumTxs
+		ante.NewSetUpContextDecorator(),
+		ante.NewMempoolFeeDecorator(),
+		ante.NewValidateBasicDecorator(),
+		ethante.NewMinGasPriceDecorator(options.FeeMarketKeeper, options.EvmKeeper),
+		ante.NewTxTimeoutHeightDecorator(),
+		ante.NewValidateMemoDecorator(options.AccountKeeper),
+		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
+		cantoante.NewVestingDelegationDecorator(options.AccountKeeper, options.StakingKeeper, options.Cdc),
+		cantoante.NewValidatorCommissionDecorator(options.Cdc),
+		// SetPubKeyAccountTypeDecorator must be called before all signature verification decorators
+		NewSetPubKeyAccountTypeDecorator(options.AccountKeeper),
+		ante.NewValidateSigCountDecorator(options.AccountKeeper),
+		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
+		// Note: signature verification uses EIP instead of the cosmos signature validator
+		ethante.NewEip712SigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
+		ibcante.NewAnteDecorator(options.IBCKeeper),
+		ethante.NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
+	)
+}

--- a/app/ante/interfaces.go
+++ b/app/ante/interfaces.go
@@ -1,0 +1,25 @@
+package ante
+
+import (
+	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/ethereum/go-ethereum/params"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+)
+
+// EvmKeeper defines the expected keeper interface used on the AnteHandler
+type EvmKeeper interface {
+	GetParams(ctx sdk.Context) (params evmtypes.Params)
+	ChainID() *big.Int
+	GetBaseFee(ctx sdk.Context, ethCfg *params.ChainConfig) *big.Int
+}
+
+type AccountKeeper interface {
+	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
+	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
+	GetParams(ctx sdk.Context) (params authtypes.Params)
+	GetModuleAddress(moduleName string) sdk.AccAddress
+}

--- a/app/ante/pubkey_account.go
+++ b/app/ante/pubkey_account.go
@@ -1,0 +1,183 @@
+package ante
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	ethsecp "github.com/evmos/ethermint/crypto/ethsecp256k1"
+	ethtypes "github.com/evmos/ethermint/types"
+)
+
+var (
+	// simulation signature values used to estimate gas consumption
+	key                = make([]byte, secp256k1.PubKeySize)
+	simSecp256k1Pubkey = &secp256k1.PubKey{Key: key}
+)
+
+func init() {
+	// This decodes a valid hex string into a sepc256k1Pubkey for use in transaction simulation
+	bz, _ := hex.DecodeString("035AD6810A47F073553FF30D2FCC7E0D3B1C0B74B61A1AAA2582344037151E143A")
+	copy(key, bz)
+	simSecp256k1Pubkey.Key = key
+}
+
+// SetPubKeyAccountTypeDecorator sets PubKeys in context for any signer which does not already have pubkey set
+// Also sets the account type to EthAccount for Ethermint pubkeys
+// PubKeys must be set in context for all signers before any other sigverify decorators run
+// CONTRACT: Tx must implement SigVerifiableTx interface
+//
+// Note that this is largely a copy of the SetPubKeyDecorator from the auth module, with the only difference being
+// that it sets the account type to EthAccount for Ethermint pubkeys if the original account was a BaseAccount
+type SetPubKeyAccountTypeDecorator struct {
+	ak AccountKeeper
+}
+
+func NewSetPubKeyAccountTypeDecorator(ak AccountKeeper) SetPubKeyAccountTypeDecorator {
+	return SetPubKeyAccountTypeDecorator{
+		ak: ak,
+	}
+}
+
+func (spkd SetPubKeyAccountTypeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+	}
+
+	pubkeys, err := sigTx.GetPubKeys()
+	if err != nil {
+		return ctx, err
+	}
+	signers := sigTx.GetSigners()
+
+	for i, pk := range pubkeys {
+		// PublicKey was omitted from slice since it has already been set in context
+		if pk == nil {
+			if !simulate {
+				continue
+			}
+			pk = simSecp256k1Pubkey
+		}
+		// Only make check if simulate=false
+		if !simulate && !bytes.Equal(pk.Address(), signers[i]) {
+			return ctx, sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey,
+				"pubKey does not match signer address %s with signer index: %d", signers[i], i)
+		}
+
+		acc, err := authante.GetSignerAcc(ctx, spkd.ak, signers[i])
+		if err != nil {
+			return ctx, err
+		}
+		// account already has pubkey set,no need to reset
+		if acc.GetPubKey() != nil {
+			continue
+		}
+
+		// CHANGES FROM COSMOS UPSTREAM IMPLEMENTATION START --------------------------------------------------------------
+		// If the account is a BaseAccount and the pubkey is an Ethermint pubkey, replace the account with an EthAccount
+		baseAccount, ok := acc.(*authtypes.BaseAccount)
+		if pk.Type() == ethsecp.KeyType && ok {
+			replacement := ethtypes.ProtoAccount() // Sets the codehash for us, but does not set any BaseAccount values
+
+			// Copy over the BaseAccount values, which may include everything EXCEPT the PubKey
+			if err = replacement.SetAddress(baseAccount.GetAddress()); err != nil {
+				return ctx, sdkerrors.Wrap(err, "unable to set address on replacement EthAccount")
+			}
+			if err = replacement.SetAccountNumber(baseAccount.GetAccountNumber()); err != nil {
+				return ctx, sdkerrors.Wrap(err, "unable to set account number on replacement EthAccount")
+			}
+			if err = replacement.SetSequence(baseAccount.GetSequence()); err != nil {
+				return ctx, sdkerrors.Wrap(err, "unable to set sequence on replacement EthAccount")
+			}
+
+			acc = replacement
+		}
+		// CHANGES FROM COSMOS UPSTREAM IMPLEMENTATION END --------------------------------------------------------------
+
+		err = acc.SetPubKey(pk)
+		if err != nil {
+			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, err.Error())
+		}
+		spkd.ak.SetAccount(ctx, acc)
+	}
+
+	// Also emit the following events, so that txs can be indexed by these
+	// indices:
+	// - signature (via `tx.signature='<sig_as_base64>'`),
+	// - concat(address,"/",sequence) (via `tx.acc_seq='cosmos1abc...def/42'`).
+	sigs, err := sigTx.GetSignaturesV2()
+	if err != nil {
+		return ctx, err
+	}
+
+	var events sdk.Events
+	for i, sig := range sigs {
+		events = append(events, sdk.NewEvent(sdk.EventTypeTx,
+			sdk.NewAttribute(sdk.AttributeKeyAccountSequence, fmt.Sprintf("%s/%d", signers[i], sig.Sequence)),
+		))
+
+		sigBzs, err := signatureDataToBz(sig.Data)
+		if err != nil {
+			return ctx, err
+		}
+		for _, sigBz := range sigBzs {
+			events = append(events, sdk.NewEvent(sdk.EventTypeTx,
+				sdk.NewAttribute(sdk.AttributeKeySignature, base64.StdEncoding.EncodeToString(sigBz)),
+			))
+		}
+	}
+
+	ctx.EventManager().EmitEvents(events)
+
+	return next(ctx, tx, simulate)
+}
+
+// signatureDataToBz converts a SignatureData into raw bytes signature.
+// For SingleSignatureData, it returns the signature raw bytes.
+// For MultiSignatureData, it returns an array of all individual signatures,
+// as well as the aggregated signature.
+func signatureDataToBz(data signing.SignatureData) ([][]byte, error) {
+	if data == nil {
+		return nil, fmt.Errorf("got empty SignatureData")
+	}
+
+	switch data := data.(type) {
+	case *signing.SingleSignatureData:
+		return [][]byte{data.Signature}, nil
+	case *signing.MultiSignatureData:
+		sigs := [][]byte{}
+		var err error
+
+		for _, d := range data.Signatures {
+			nestedSigs, err := signatureDataToBz(d)
+			if err != nil {
+				return nil, err
+			}
+			sigs = append(sigs, nestedSigs...)
+		}
+
+		multisig := cryptotypes.MultiSignature{
+			Signatures: sigs,
+		}
+		aggregatedSig, err := multisig.Marshal()
+		if err != nil {
+			return nil, err
+		}
+		sigs = append(sigs, aggregatedSig)
+
+		return sigs, nil
+	default:
+		return nil, sdkerrors.ErrInvalidType.Wrapf("unexpected signature data type %T", data)
+	}
+}

--- a/app/ante/utils_test.go
+++ b/app/ante/utils_test.go
@@ -1,0 +1,176 @@
+package ante_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/Canto-Network/Canto/v5/app"
+	client "github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/evmos/ethermint/crypto/ethsecp256k1"
+	"github.com/evmos/ethermint/encoding"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+	feemarkettypes "github.com/evmos/ethermint/x/feemarket/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/tmhash"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
+	"github.com/tendermint/tendermint/version"
+)
+
+var s *AnteTestSuite
+
+type AnteTestSuite struct {
+	suite.Suite
+
+	ctx   sdk.Context
+	app   *app.Canto
+	denom string
+}
+
+func (suite *AnteTestSuite) SetupTest(isCheckTx bool) {
+	t := suite.T()
+	privCons, err := ethsecp256k1.GenerateKey()
+	require.NoError(t, err)
+	consAddress := sdk.ConsAddress(privCons.PubKey().Address())
+
+	suite.app = app.Setup(isCheckTx, feemarkettypes.DefaultGenesisState())
+	suite.ctx = suite.app.BaseApp.NewContext(isCheckTx, tmproto.Header{
+		Height:          1,
+		ChainID:         "canto_9001-1",
+		Time:            time.Now().UTC(),
+		ProposerAddress: consAddress.Bytes(),
+
+		Version: tmversion.Consensus{
+			Block: version.BlockProtocol,
+		},
+		LastBlockId: tmproto.BlockID{
+			Hash: tmhash.Sum([]byte("block_id")),
+			PartSetHeader: tmproto.PartSetHeader{
+				Total: 11,
+				Hash:  tmhash.Sum([]byte("partset_header")),
+			},
+		},
+		AppHash:            tmhash.Sum([]byte("app")),
+		DataHash:           tmhash.Sum([]byte("data")),
+		EvidenceHash:       tmhash.Sum([]byte("evidence")),
+		ValidatorsHash:     tmhash.Sum([]byte("validators")),
+		NextValidatorsHash: tmhash.Sum([]byte("next_validators")),
+		ConsensusHash:      tmhash.Sum([]byte("consensus")),
+		LastResultsHash:    tmhash.Sum([]byte("last_result")),
+	})
+
+	suite.denom = "acanto"
+	evmParams := suite.app.EvmKeeper.GetParams(suite.ctx)
+	evmParams.EvmDenom = suite.denom
+	suite.app.EvmKeeper.SetParams(suite.ctx, evmParams)
+}
+
+func TestAnteTestSuite(t *testing.T) {
+	s = new(AnteTestSuite)
+	suite.Run(t, s)
+}
+
+// Commit commits and starts a new block with an updated context.
+func (suite *AnteTestSuite) Commit() {
+	suite.CommitAfter(time.Second * 0)
+}
+
+// Commit commits a block at a given time.
+func (suite *AnteTestSuite) CommitAfter(t time.Duration) {
+	header := suite.ctx.BlockHeader()
+	suite.app.EndBlock(abci.RequestEndBlock{Height: header.Height})
+	_ = suite.app.Commit()
+
+	header.Height += 1
+	header.Time = header.Time.Add(t)
+	suite.app.BeginBlock(abci.RequestBeginBlock{
+		Header: header,
+	})
+
+	// update ctx
+	suite.ctx = suite.app.BaseApp.NewContext(false, header)
+}
+
+func (s *AnteTestSuite) CreateTestTxBuilder(gasPrice sdk.Int, denom string, msgs ...sdk.Msg) client.TxBuilder {
+	encodingConfig := encoding.MakeConfig(app.ModuleBasics)
+	gasLimit := uint64(1000000)
+
+	txBuilder := encodingConfig.TxConfig.NewTxBuilder()
+
+	txBuilder.SetGasLimit(gasLimit)
+	fees := &sdk.Coins{{Denom: denom, Amount: gasPrice.MulRaw(int64(gasLimit))}}
+	txBuilder.SetFeeAmount(*fees)
+	err := txBuilder.SetMsgs(msgs...)
+	s.Require().NoError(err)
+	return txBuilder
+}
+
+func (s *AnteTestSuite) CreateEthTestTxBuilder(msgEthereumTx *evmtypes.MsgEthereumTx) client.TxBuilder {
+	encodingConfig := encoding.MakeConfig(app.ModuleBasics)
+	option, err := codectypes.NewAnyWithValue(&evmtypes.ExtensionOptionsEthereumTx{})
+	s.Require().NoError(err)
+
+	txBuilder := encodingConfig.TxConfig.NewTxBuilder()
+	builder, ok := txBuilder.(authtx.ExtensionOptionsTxBuilder)
+	s.Require().True(ok)
+	builder.SetExtensionOptions(option)
+
+	err = txBuilder.SetMsgs(msgEthereumTx)
+	s.Require().NoError(err)
+
+	txData, err := evmtypes.UnpackTxData(msgEthereumTx.Data)
+	s.Require().NoError(err)
+
+	fees := sdk.Coins{{Denom: s.denom, Amount: sdk.NewIntFromBigInt(txData.Fee())}}
+	builder.SetFeeAmount(fees)
+	builder.SetGasLimit(msgEthereumTx.GetGas())
+
+	return txBuilder
+}
+
+func (s *AnteTestSuite) BuildTestEthTx(
+	from common.Address,
+	to common.Address,
+	gasPrice *big.Int,
+	gasFeeCap *big.Int,
+	gasTipCap *big.Int,
+	accesses *ethtypes.AccessList,
+) *evmtypes.MsgEthereumTx {
+	chainID := s.app.EvmKeeper.ChainID()
+	nonce := s.app.EvmKeeper.GetNonce(
+		s.ctx,
+		common.BytesToAddress(from.Bytes()),
+	)
+	data := make([]byte, 0)
+	gasLimit := uint64(100000)
+	msgEthereumTx := evmtypes.NewTx(
+		chainID,
+		nonce,
+		&to,
+		nil,
+		gasLimit,
+		gasPrice,
+		gasFeeCap,
+		gasTipCap,
+		data,
+		accesses,
+	)
+	msgEthereumTx.From = from.String()
+	return msgEthereumTx
+}
+
+var _ sdk.Tx = &invalidTx{}
+
+type invalidTx struct{}
+
+func (invalidTx) GetMsgs() []sdk.Msg   { return []sdk.Msg{nil} }
+func (invalidTx) ValidateBasic() error { return nil }

--- a/integration_tests/test_runner/src/tests/liquid_accounts.rs
+++ b/integration_tests/test_runner/src/tests/liquid_accounts.rs
@@ -73,7 +73,10 @@ pub async fn liquid_accounts_test(
     )
     .await
     .expect("Unable to liquify account");
-    info!("Got liquify account response:\n{}", liquify_res.raw_log);
+    info!(
+        "Got liquify account response:\n{}\nTx Hash: {}\nGas used: {}",
+        liquify_res.raw_log, liquify_res.txhash, liquify_res.gas_used
+    );
 
     let (liquid_account, _eth_owner) =
         assert_correct_account(web3, &mut microtx_qc, to_liquify.ethermint_address).await;
@@ -227,7 +230,7 @@ pub async fn liquify_account(
             to_liquify,
             Fee {
                 amount: vec![fee],
-                gas_limit: 1_000_000,
+                gas_limit: 2_500_000,
                 payer: None,
                 granter: None,
             },

--- a/x/microtx/keeper/msg_server.go
+++ b/x/microtx/keeper/msg_server.go
@@ -166,6 +166,10 @@ func (m *msgServer) Liquify(c context.Context, msg *types.MsgLiquify) (*types.Ms
 		return nil, sdkerrors.Wrap(sdkerrors.ErrorInvalidSigner, "liquid infrastructure accounts must use ethermint keys, perhaps this is the first message the sender has sent?")
 	}
 
+	if m.Keeper.IsLiquidAccount(ctx, sender) {
+		return nil, types.ErrAccountAlreadyLiquid
+	}
+
 	// Call the actual liquify implementation
 	nft, err := m.Keeper.DoLiquify(ctx, sender)
 	if err != nil {

--- a/x/microtx/types/errors.go
+++ b/x/microtx/types/errors.go
@@ -5,10 +5,11 @@ import (
 )
 
 var (
-	ErrContractDeployment = sdkerrors.Register(ModuleName, 1, "contract deploy failed")
-	ErrContractCall       = sdkerrors.Register(ModuleName, 2, "contract call failed")
-	ErrNoLiquidAccount    = sdkerrors.Register(ModuleName, 3, "account is not a liquid infrastructure account")
-	ErrInvalidThresholds  = sdkerrors.Register(ModuleName, 4, "invalid liquid infrastructure account thresholds")
-	ErrInvalidMicrotx     = sdkerrors.Register(ModuleName, 5, "invalid microtx")
-	ErrInvalidContract    = sdkerrors.Register(ModuleName, 6, "invalid contract")
+	ErrContractDeployment   = sdkerrors.Register(ModuleName, 1, "contract deploy failed")
+	ErrContractCall         = sdkerrors.Register(ModuleName, 2, "contract call failed")
+	ErrNoLiquidAccount      = sdkerrors.Register(ModuleName, 3, "account is not a liquid infrastructure account")
+	ErrInvalidThresholds    = sdkerrors.Register(ModuleName, 4, "invalid liquid infrastructure account thresholds")
+	ErrInvalidMicrotx       = sdkerrors.Register(ModuleName, 5, "invalid microtx")
+	ErrInvalidContract      = sdkerrors.Register(ModuleName, 6, "invalid contract")
+	ErrAccountAlreadyLiquid = sdkerrors.Register(ModuleName, 7, "account is already a liquid infrastructure account")
 )


### PR DESCRIPTION
2 problems solved with this PR:

1. Cosmos pubkeys can be stored under EthAccounts. This isn't a problem for the chain but is a problem for Cosmos wallets getting the wrong account type when querying the account number + sequence - they error out despite the value being in the returned type
2. EVM Txs do not assign a pubkey, but they increment the account's sequence. This is not a problem for the chain but it is confusing and seems like bad behavior